### PR TITLE
(gha) Test install in gha on other os's using containers

### DIFF
--- a/.github/workflows/pr_testing.yaml
+++ b/.github/workflows/pr_testing.yaml
@@ -20,15 +20,22 @@ jobs:
         run: shellcheck tasks/*.sh
 
   test-install-task-on-ubuntu:
+    strategy:
+      matrix:
+        os-details:
+          - os: ubuntu-20.04
+            codename: focal
+          - os: ubuntu-22.04
+            codename: jammy
     # Perforce hasn't yet released bolt on 24.04.
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os-details.os }}
     needs: shellcheck
     steps:
       - uses: actions/checkout@v4
       - name: Install Bolt
         run: |-
-          wget https://apt.puppet.com/puppet-tools-release-jammy.deb
-          sudo dpkg -i puppet-tools-release-jammy.deb
+          wget https://apt.puppet.com/puppet-tools-release-${{ matrix.os-details.codename }}.deb
+          sudo dpkg -i puppet-tools-release-${{ matrix.os-details.codename }}.deb
           sudo apt update
           sudo apt install -y puppet-bolt
       - name: Install module dependencies
@@ -38,3 +45,59 @@ jobs:
       - name: Verify openvox-agent is installed
         run: |-
           [[ "$(/opt/puppetlabs/bin/puppet --version)" =~ [0-9]+\.[0-9]+\.[0-9]+ ]]
+
+  test-install-task-on-other-os-via-containers:
+    strategy:
+      matrix:
+        image:
+          - rockylinux:8
+          - rockylinux:9
+          - debian:10
+          - debian:11
+          - debian:12
+          # Need to pull in the repo GPG keys for sles
+          #          - registry.suse.com/suse/sle15:15.6
+    needs: shellcheck
+    runs-on: ubuntu-latest
+    container: ${{ matrix.image }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: puppetlabs/puppetlabs-facts
+          path: facts
+      - name: debugging
+        run: |
+          pwd
+          echo "Running on ${{ matrix.image }}"
+          ls -l
+          echo "${GITHUB_WORKSPACE}"
+          ls -l "${GITHUB_WORKSPACE}/.."
+      - name: Ensure wget is installed (apt)
+        if: startsWith(matrix.image, 'debian')
+        run: |
+          if ! command -v wget &> /dev/null; then
+            apt update
+            apt install -y wget
+          fi
+      - name: Ensure wget is installed (dnf)
+        if: startsWith(matrix.image, 'rocky')
+        run: |
+          if ! command -v wget &> /dev/null; then
+            dnf install -y wget
+          fi
+      - name: Ensure wget is installed (zypper)
+        if: contains(matrix.image, 'suse')
+        run: |
+          if ! command -v wget &> /dev/null; then
+            zypper install -y wget
+          fi
+      - name: Run openvox-agent install task manually
+        env:
+          PT__installdir: ${{ github.workspace }}
+          PT_collection: openvox8
+          PT_apt_source: "https://apt.overlookinfratech.com"
+          PT_yum_source: "https://yum.overlookinfratech.com"
+        run: ./tasks/install_linux.sh
+      - name: Verify openvox-agent is installed
+        run: /opt/puppetlabs/bin/puppet --version | grep -E '[0-9]+\.[0-9]+'

--- a/tasks/install_linux.sh
+++ b/tasks/install_linux.sh
@@ -71,7 +71,7 @@ set_repository() {
   local _family="$1"
 
   case $_family in
-    amazon|fedora|rhel|sles)
+    amazon|fedora|el|sles)
       repository=$yum_source
       ;;
     debian|ubuntu)
@@ -88,7 +88,7 @@ set_package_type() {
   local _family="$1"
 
   case $_family in
-    amazon|fedora|rhel|sles)
+    amazon|fedora|el|sles)
       package_type='rpm'
       package_file_suffix='noarch.rpm'
       ;;
@@ -112,7 +112,7 @@ set_collection_url() {
       family='amazon'
       ;;
     RHEL|RedHat|CentOS|Scientific|OracleLinux|Rocky|AlmaLinux)
-      family='rhel'
+      family='el'
       ;;
     Fedora)
       family='fedora'
@@ -136,12 +136,14 @@ set_collection_url() {
   set_package_type $family
 
   if [ "${package_type}" == 'rpm' ]; then
-    package_name="${collection}-release-${family}-${full_version}.${package_file_suffix}"
+    major_version=${full_version%%.*}
+    assigned 'major_version'
+    package_name="${collection}-release-${family}-${major_version}.${package_file_suffix}"
   else
     package_name="${collection}-release-${family}${full_version}.${package_file_suffix}"
   fi
   package_url="${repository}/${package_name}"
-  
+
   assigned 'package_name'
   assigned 'package_url'
 }


### PR DESCRIPTION
Github actions only provides a few ubuntu vms. This patch takes a stab at adding a matrix of base os containers to run on ubuntu 24.04 in an attempt to simulate install on those variants.

To simplify the workflow, I'm not attempting to install bolt as a runner for these additional cases. Instead, the facts module is checked out and I simulate the run environment by supplying the Bolt PT__installdir var to the task script executed directly.