### PR TITLE
(tasks) Set defaults for collection and repos in install_linux.sh

### DIFF
--- a/tasks/install.json
+++ b/tasks/install.json
@@ -2,12 +2,12 @@
   "description": "Installs the openvox-agent package.",
   "parameters": {
     "version": {
-      "description": "The version of the openvox-agent package to install. Defaults to latest.",
+      "description": "TODO The version of the openvox-agent package to install. Defaults to latest.",
       "type": "Optional[String]"
     },
     "collection": {
       "description": "The openvox collection to install from.",
-      "type": "String",
+      "type": "Optional[String]",
       "default": "openvox8"
     },
     "apt_source": {

--- a/tasks/install_linux.sh
+++ b/tasks/install_linux.sh
@@ -6,11 +6,11 @@ set -e
 # shellcheck disable=SC2154
 installdir=$PT__installdir
 # shellcheck disable=SC2154
-collection=$PT_collection
+collection=${PT_collection:-'openvox8'}
 # shellcheck disable=SC2154
-yum_source=$PT_yum_source
+yum_source=${PT_yum_source:-'https://yum.overlookinfratech.com'}
 # shellcheck disable=SC2154
-apt_source=$PT_apt_source
+apt_source=${PT_apt_source:-'https://apt.overlookinfratech.com'}
 
 tempdir=$(mktemp -d)
 trap 'rm -rf $tempdir' EXIT
@@ -213,6 +213,7 @@ install_release_package() {
   esac
 }
 
+# TODO add support for the version parameter.
 install_package() {
   local _package="$1"
 


### PR DESCRIPTION
When the openvox_bootstrap::install task is called by Bolt's puppet_library plugin mechanism, parameter defaults from tasks/install.json are not referenced. Providing the defaults directly in the install_linux.sh allows the plugin to work without requiring that collection, apt_source and yum_source are explicitly set in the Bolt plugin hook configuration.

This pr also notes that the install version parameter isn't used yet.