### PR TITLE
(tasks,gha) Implement version parameter for install task

### DIFF
--- a/.github/workflows/pr_testing.yaml
+++ b/.github/workflows/pr_testing.yaml
@@ -72,4 +72,33 @@ jobs:
           PT_yum_source: "https://yum.overlookinfratech.com"
         run: ./openvox_bootstrap/tasks/install_linux.sh
       - name: Verify openvox-agent is installed
-        run: /opt/puppetlabs/bin/puppet --version | grep -E '[0-9]+\.[0-9]+'
+        run: /opt/puppetlabs/bin/puppet --version | grep -E '8\.[0-9]+'
+
+  test-install-version:
+    strategy:
+      matrix:
+        image:
+          - rockylinux:9
+          - fedora:41
+          - debian:12
+          - ubuntu:24.04
+          # Need to pull in the repo GPG keys for sles
+          #          - registry.suse.com/suse/sle15:15.6
+    needs: shellcheck
+    runs-on: ubuntu-latest
+    container: ${{ matrix.image }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: openvox_bootstrap
+      - id: prep
+        uses: ./openvox_bootstrap/.github/actions/container_task_prep
+      - name: Run openvox-agent install task manually
+        env:
+          PT__installdir: ${{ github.workspace }}
+          PT_version: "8.14.0"
+          PT_apt_source: "https://apt.overlookinfratech.com"
+          PT_yum_source: "https://yum.overlookinfratech.com"
+        run: ./openvox_bootstrap/tasks/install_linux.sh
+      - name: Verify openvox-agent is installed
+        run: /opt/puppetlabs/bin/puppet --version | grep '8.14.0'

--- a/files/common.sh
+++ b/files/common.sh
@@ -166,21 +166,42 @@ install_package_file() {
   esac
 }
 
-# TODO add support for the version parameter.
+# Install a package using the system package manager.
 install_package() {
   local _package="$1"
+  local _version="$2"
+  local _family="${3:-${family}}"
 
-  info "Installing ${_package}"
+  info "Installing ${_package} ${_version}"
+
+  local _package_and_version
+  if [[ -n "${_version}" ]] && [[ "${_version}" != 'latest' ]]; then
+    if [[ -z "${_family}" ]]; then
+      set_family "${platform}"
+      _family="${family}"
+    fi
+    case $_family in
+      debian|ubuntu)
+        _package_and_version="${_package}=${_version}"
+        ;;
+      *)
+        _package_and_version="${_package}-${_version}"
+        ;;
+    esac
+  else
+    _package_and_version="${_package}"
+  fi
+
   if exists 'dnf'; then
-    exec_and_capture dnf install -y "$_package"
+    exec_and_capture dnf install -y "${_package_and_version}"
   elif exists 'yum'; then
-    exec_and_capture yum install -y "$_package"
+    exec_and_capture yum install -y "${_package_and_version}"
   elif exists 'zypper'; then
-    exec_and_capture zypper install -y "$_package"
+    exec_and_capture zypper install -y "${_package_and_version}"
   elif exists 'apt'; then
-    exec_and_capture apt install -y "$_package"
+    exec_and_capture apt install -y "${_package_and_version}"
   elif exists 'apt-get'; then
-    exec_and_capture apt-get install -y "$_package"
+    exec_and_capture apt-get install -y "${_package_and_version}"
   else
     fail "Unable to install ${_package}. Neither dnf, yum, zypper, apt nor apt-get are installed."
   fi

--- a/files/common.sh
+++ b/files/common.sh
@@ -95,7 +95,12 @@ set_platform() {
 
 # Set the OS family variable based on the platform.
 set_family() {
-  local _platform="$1"
+  local _platform="${1:-${platform}}"
+
+  if [[ -z "${_platform}" ]]; then
+    set_platform
+    _platform="${platform}"
+  fi
 
   case $_platform in
     Amazon)
@@ -128,7 +133,12 @@ set_family() {
 #  package_type - rpm or deb or...
 #  package_file_suffix - the file extension for the release package name
 set_package_type() {
-  local _family="$1"
+  local _family="${1:-${family}}"
+
+  if [[ -z "${_family}" ]]; then
+    set_family "${platform}"
+    _family="${family}"
+  fi
 
   case $_family in
     amazon|fedora|el|sles)

--- a/tasks/install.json
+++ b/tasks/install.json
@@ -2,7 +2,7 @@
   "description": "Installs the openvox-agent package.",
   "parameters": {
     "version": {
-      "description": "TODO The version of the openvox-agent package to install. Defaults to latest.",
+      "description": "The version of the openvox-agent package to install. Defaults to latest.",
       "type": "Optional[String]"
     },
     "collection": {

--- a/tasks/install_linux.sh
+++ b/tasks/install_linux.sh
@@ -6,6 +6,8 @@ set -e
 # shellcheck disable=SC2154
 installdir=$PT__installdir
 # shellcheck disable=SC2154
+version=${PT_version:-'latest'}
+# shellcheck disable=SC2154
 collection=${PT_collection:-'openvox8'}
 # shellcheck disable=SC2154
 yum_source=${PT_yum_source:-'https://yum.overlookinfratech.com'}
@@ -70,6 +72,41 @@ install_release_package() {
   fi
 }
 
+# Installs the openvox-agent package using the system package manager.
+# The version is optional, and if not provided, the latest version
+# available in the repository will be installed.
+install_openvox_agent() {
+  local _version="$1"
+  local _family="$2"
+  local _full_version="$3"
+
+  local _package_version
+  if [[ -n "${_version}" ]] && [[ "${_version}" != 'latest' ]]; then
+    case $_family in
+      debian|ubuntu)
+        # Need the full packaging version for deb.
+        # As an example, for openvox-agent 8.14.0 on ubuntu 24.04:
+        # 8.14.0-1+ubuntu24.04
+        if [[ "${_version}" =~ - ]]; then
+          # Caller's version already has a '-' seprator, so we
+          # should respect that they have probably supplied some
+          # full package version string.
+          _package_version="${_version}"
+        else
+          _package_version="${_version}-1+${_family}${_full_version}"
+        fi
+        ;;
+      *)
+        # rpm packages should be fine so long as the shorter form
+        # matches uniquely.
+        _package_version="${_version}"
+        ;;
+    esac
+  fi
+
+  install_package openvox-agent "${_package_version}" "${_family}"
+}
+
 # Get platform information
 set_platform
 # Set collection release package url based on platform
@@ -82,4 +119,4 @@ download "${package_url}" "${local_release_package}"
 # packages from the collection using the platform package manager.
 install_release_package "${local_release_package}" "${package_type}"
 # Use the platform package manager to install openvox-agent
-install_package 'openvox-agent'
+install_openvox_agent "${version}" "${family}" "${full_version}"


### PR DESCRIPTION
Setting openvox_bootstrap::install version will install that version of the openvox-agent. Does not test for mismatch between collection and version major.