### PR TITLE
(tasks,gha) Fix a case issue that was blocking almalinux installs

### DIFF
--- a/.github/workflows/pr_testing.yaml
+++ b/.github/workflows/pr_testing.yaml
@@ -46,6 +46,8 @@ jobs:
     strategy:
       matrix:
         image:
+          - almalinux:8
+          - almalinux:9
           - rockylinux:8
           - rockylinux:9
           - debian:10

--- a/.github/workflows/pr_testing_install_build_artifact.yaml
+++ b/.github/workflows/pr_testing_install_build_artifact.yaml
@@ -36,6 +36,8 @@ jobs:
     strategy:
       matrix:
         image:
+          - almalinux:8
+          - almalinux:9
           - rockylinux:8
           - rockylinux:9
           - debian:10

--- a/files/common.sh
+++ b/files/common.sh
@@ -102,23 +102,24 @@ set_family() {
     _platform="${platform}"
   fi
 
-  case $_platform in
-    Amazon)
+  # Downcase the platform so as to avoid case issues.
+  case ${_platform,,} in
+    amazon)
       family='amazon'
       ;;
-    RHEL|RedHat|CentOS|Scientific|OracleLinux|Rocky|AlmaLinux)
+    rhel|redhat|centos|scientific|oraclelinux|rocky|almalinux)
       family='el'
       ;;
-    Fedora)
+    fedora)
       family='fedora'
       ;;
-    SLES|Suse)
+    sles|suse)
       family='sles'
       ;;
-    Debian)
+    debian)
       family='debian'
       ;;
-    Ubuntu)
+    ubuntu)
       family='ubuntu'
       ;;
     *)


### PR DESCRIPTION
Facter will return a name of AlmaLinux, but puppetlabs-facts tasks will return an name of Almalinux. I've updated the set_family() function to ignore $platform case to fix this, and added almalinux containers to the github text matrices.